### PR TITLE
Reduce grub menu timeout to 1 second

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -4,6 +4,8 @@ wget -L http://get.opencsw.org/now
 echo y |  pkgadd -v  -d now  all
 rm -f now
 
+bootadm set-menu timeout=1
+
 cp .bashrc .bash_profile
 gsed -i 's|#SUPATH=/usr/bin:/usr/sbin|SUPATH=/usr/bin:/usr/sbin:/opt/csw/bin|' /etc/default/login
 


### PR DESCRIPTION
The current default value is 30, which leads to the VM sitting at the grub menu for 30 seconds before automatically booting into Solaris. We can reduce that to 1 second.