### PR TITLE
Preinstalled the gcc, g++, autotools and rsync packages.

### DIFF
--- a/conf/solaris-11.4.conf
+++ b/conf/solaris-11.4.conf
@@ -19,6 +19,7 @@ VM_RSYNC_PKG="rsync"
 VM_SSHFS_PKG=""
 VM_DISK="ide"
 
+VM_PRE_INSTALL_PKGS="autoconf automake gcc5core gcc5g++ libtool rsync"
 
 VM_LOGIN_TAG="solaris console login"
 VM_OPTS="conf/solaris-11.4.opts.txt"


### PR DESCRIPTION
Relates to the following issue : https://github.com/vmactions/solaris-vm/issues/37.